### PR TITLE
Suggested 'third way'...

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -2,7 +2,7 @@
 
 ## Basic usage
 
-There should be two ways of using friendly-traceback.
+There should be three ways of using friendly-traceback.
 
 1. As an import hook
 
@@ -11,13 +11,19 @@ import friendly_traceback
 friendly_traceback.install()  # sys.excepthook = friendly_traceback.explain
 ```
 
-2.Catching exceptions locally
+2. Catching exceptions locally
 
 ```py
 try:
     # Some code
 except Exception:
     friendly_traceback.explain(*sys.exc_info())
+```
+
+3. When launching a Python script (or the REPL)
+
+```bash
+python -m friendly_traceback myscript.py
 ```
 
 By default, friendly tracebacks will be written to sys.stderr.


### PR DESCRIPTION
Hi @aroberge -- as promised some feedback.

I've suggested a third way to launch friendly_traceback. I.e. running it as a module which automatically wraps sys.excepthook before running the referenced Python script. This would make it easy for code editors (like Mu) to use friendly_traceback as a feature flag, rather then relying on beginner developers to have to incorporate seemingly magic incantations at the start of their scripts. My guess is you only need a very simple addition, along the lines of (untested code, off the top of my head):

```py
if __name__ == "__main__":
    install()  # Enable friendly_traceback...
    if len(sys.argv) > 1:
        # Run the passed in script.
        filename = sys.argv[1]
        sys.argv = sys.argv[1:]
        with open(filename) as f:
            script = f.read()
            exec(script, globals(), locals())
    else:
        # Start as REPL.
        import code
        code.InteractiveConsole(locals=globals()).interact()
```

All the other features you mention sound good to me. I like the three levels of verbosity very much, although it's not clear to me how extensibility with custom exceptions might work. I notice you an example that uses the `extend` function, but I'm not sure how one specifies how to handle such exceptions (I presume this is TBD).