### PR TITLE
FIX: TypeError: can only concatenate str (not "bool") to str

### DIFF
--- a/friendly_traceback/locales/fr/LC_MESSAGES/friendly.po
+++ b/friendly_traceback/locales/fr/LC_MESSAGES/friendly.po
@@ -5,9 +5,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2020-04-10 16:39-0300\n"
-"PO-Revision-Date: 2020-04-10 16:45-0300\n"
-"Last-Translator: André Roberge <andre.roberge@gmail.com>\n"
+"POT-Creation-Date: 2020-06-25 22:37+0200\n"
+"PO-Revision-Date: 2020-06-25 22:41+0200\n"
+"Last-Translator: Julien Palard <julien@palard.fr>\n"
 "Language-Team: \n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
@@ -1104,7 +1104,7 @@ msgstr ""
 "à la parenthèse de gauche ''{opening}'.\n"
 "\n"
 
-#: message_analyzer.py:417
+#: message_analyzer.py:417 message_analyzer.py:568
 msgid ""
 "I will attempt to be give a bit more information.\n"
 "\n"
@@ -1227,22 +1227,18 @@ msgid ""
 "Python tells us that the it reached the end of the file\n"
 "and expected more content.\n"
 "\n"
-"I will attempt to be give a bit more information.\n"
-"\n"
 msgstr ""
 "Python nous dit que le il a atteint la fin du fichier\n"
 "et s'attendait à plus de contenu.\n"
 "\n"
-"Je vais essayer de donner un peu plus d'informations.\n"
-"\n"
 
-#: message_analyzer.py:581 source_analyzer.py:84
+#: message_analyzer.py:587 source_analyzer.py:84
 msgid "The closing {bracket} on line {linenumber} does not match anything.\n"
 msgstr ""
 "Le symbole {bracket} à la ligne {linenumber} n'a pas de symbole ouvrant qui "
 "lui correspond.\n"
 
-#: message_analyzer.py:591
+#: message_analyzer.py:597
 msgid ""
 "In Python, you can call functions with only positional arguments\n"
 "\n"
@@ -1277,7 +1273,7 @@ msgstr ""
 "Selon Python, vous avez utilisé des arguments positionnels après des "
 "arguments nommés.\n"
 
-#: message_analyzer.py:608
+#: message_analyzer.py:614
 msgid ""
 "In Python, you can define functions with only positional arguments\n"
 "\n"
@@ -1314,7 +1310,7 @@ msgstr ""
 "Selon Python, vous avez utilisé des arguments positionnels après des "
 "arguments nommés.\n"
 
-#: message_analyzer.py:628
+#: message_analyzer.py:634
 msgid ""
 "Perhaps you need to type print({message})?\n"
 "\n"

--- a/friendly_traceback/locales/friendly.pot
+++ b/friendly_traceback/locales/friendly.pot
@@ -5,12 +5,12 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-04-10 16:39-0300\n"
+"POT-Creation-Date: 2020-06-25 22:37+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=cp1252\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: pygettext.py 1.5\n"
 
@@ -788,7 +788,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: message_analyzer.py:417
+#: message_analyzer.py:417 message_analyzer.py:568
 msgid ""
 "I will attempt to be give a bit more information.\n"
 "\n"
@@ -870,16 +870,14 @@ msgid ""
 "Python tells us that the it reached the end of the file\n"
 "and expected more content.\n"
 "\n"
-"I will attempt to be give a bit more information.\n"
-"\n"
 msgstr ""
 
-#: message_analyzer.py:581 source_analyzer.py:84
+#: message_analyzer.py:587 source_analyzer.py:84
 msgid ""
 "The closing {bracket} on line {linenumber} does not match anything.\n"
 msgstr ""
 
-#: message_analyzer.py:591
+#: message_analyzer.py:597
 msgid ""
 "In Python, you can call functions with only positional arguments\n"
 "\n"
@@ -897,7 +895,7 @@ msgid ""
 "According to Python, you used positional arguments after keyword ones.\n"
 msgstr ""
 
-#: message_analyzer.py:608
+#: message_analyzer.py:614
 msgid ""
 "In Python, you can define functions with only positional arguments\n"
 "\n"
@@ -915,7 +913,7 @@ msgid ""
 "According to Python, you used positional arguments after keyword ones.\n"
 msgstr ""
 
-#: message_analyzer.py:628
+#: message_analyzer.py:634
 msgid ""
 "Perhaps you need to type print({message})?\n"
 "\n"

--- a/friendly_traceback/message_analyzer.py
+++ b/friendly_traceback/message_analyzer.py
@@ -557,12 +557,18 @@ def unexpected_eof_while_parsing(
     response = _(
         "Python tells us that the it reached the end of the file\n"
         "and expected more content.\n\n"
-        "I will attempt to be give a bit more information.\n\n"
     )
 
-    response += source_analyzer.look_for_missing_bracket(
+    additional_response = source_analyzer.look_for_missing_bracket(
         source_lines=source_lines, max_linenumber=linenumber, offset=offset
     )
+
+    if additional_response:
+        response += (
+            _("I will attempt to be give a bit more information.\n\n")
+            + additional_response
+        )
+
     return response
 
 

--- a/tests/except/test_overflow_error.py
+++ b/tests/except/test_overflow_error.py
@@ -7,7 +7,10 @@ def test_overflow_error():
     except Exception:
         friendly_traceback.explain(redirect="capture")
     result = friendly_traceback.get_output()
-    assert "OverflowError: (34, 'Result too large')" in result
+    assert (
+        "OverflowError: (34, 'Result too large')" in result
+        or "OverflowError: (34, 'Numerical result out of range')" in result
+    )
     if friendly_traceback.get_lang() == "en":
         assert "OverflowError is raised when the result" in result
     return result

--- a/tests/syntax/catch_syntax_error.py
+++ b/tests/syntax/catch_syntax_error.py
@@ -77,6 +77,7 @@ causes = {
     "raise_syntax_error63": "You used the nonlocal keyword at a module level",
     "raise_syntax_error64": "keyword argument should appear only once in a function definition",
     "raise_syntax_error65": "keyword argument should appear only once in a function call",
+    "raise_syntax_error66": "Python tells us that the it reached the end of the file",
 }
 
 if sys.version_info < (3, 8):

--- a/tests/syntax/raise_syntax_error66.py
+++ b/tests/syntax/raise_syntax_error66.py
@@ -1,0 +1,3 @@
+'''Should raise SyntaxError: unexpected EOF while parsing'''
+
+for i in range(10):

--- a/tests/unit/test_console.py
+++ b/tests/unit/test_console.py
@@ -2,7 +2,7 @@ import subprocess
 
 sessions = [
     (
-        "python -im friendly_traceback tests.except.test_name_error",
+        ["python", "-im", "friendly_traceback", "tests.except.test_name_error"],
         "a = 41 \na+=1\nprint(a)\nd=e\n",
         ["42", "NameError", "-->6:         b = c"],
         ["-->1: d=e", "NameError"],


### PR DESCRIPTION
Bonsoir André,

I encontered a bug with:

```
$ cat reproducer.py 
for i in range(10):
```

<details><summary>giving a TypeError: can only concatenate str (not "bool") to str</summary>
<p>

```
$ python -m friendly_traceback reproducer.py
Error in sys.excepthook:
Traceback (most recent call last):
  File "/home/mdk/clones/friendly-traceback/friendly_traceback/core.py", line 84, in exception_hook
    etype, value, tb, session.write_err
  File "/home/mdk/clones/friendly-traceback/friendly_traceback/core.py", line 357, in get_traceback_info
    set_cause(info, friendly, etype, value)  # [3]
  File "/home/mdk/clones/friendly-traceback/friendly_traceback/core.py", line 705, in set_cause
    header, cause = get_likely_cause(etype, value)
  File "/home/mdk/clones/friendly-traceback/friendly_traceback/core.py", line 553, in get_likely_cause
    cause = info_specific.get_cause[etype.__name__](etype, value)
  File "/home/mdk/clones/friendly-traceback/friendly_traceback/info_specific.py", line 164, in syntax_error
    return analyze_syntax.find_likely_cause(value)
  File "/home/mdk/clones/friendly-traceback/friendly_traceback/analyze_syntax.py", line 29, in find_likely_cause
    return _find_likely_cause(source_lines, linenumber, message, offset)
  File "/home/mdk/clones/friendly-traceback/friendly_traceback/analyze_syntax.py", line 55, in _find_likely_cause
    offset=offset,
  File "/home/mdk/clones/friendly-traceback/friendly_traceback/message_analyzer.py", line 26, in analyze_message
    offset=offset,
  File "/home/mdk/clones/friendly-traceback/friendly_traceback/message_analyzer.py", line 564, in unexpected_eof_while_parsing
    source_lines=source_lines, max_linenumber=linenumber, offset=offset
TypeError: can only concatenate str (not "bool") to str

Original exception was:
Traceback (most recent call last):
  File "/home/mdk/.local/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/home/mdk/.local/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/mdk/clones/friendly-traceback/friendly_traceback/__main__.py", line 131, in <module>
    main()
  File "/home/mdk/clones/friendly-traceback/friendly_traceback/__main__.py", line 126, in main
    runpy.run_path(args.source, run_name="__main__")
  File "/home/mdk/.local/lib/python3.7/runpy.py", line 261, in run_path
    code, fname = _get_code_from_file(run_name, path_name)
  File "/home/mdk/.local/lib/python3.7/runpy.py", line 236, in _get_code_from_file
    code = compile(f.read(), fname, 'exec')
  File "reproducer.py", line 1
    for i in range(10):
                      ^
SyntaxError: unexpected EOF while parsing
```

</p>
</details>

As I touched a translated string, I updated `.pot` file and fixed the french translation in the `.po` file, hope I did it right.

I added a no-reg test, but while doing so I discovered the tests were not passing on my machine, due to two things: an error worded differently (I added the alternative without further investigation), and a `FileNotFoundError` due to `Popen` being called with a string instead of a list, which can't work on POSIX platforms:

> On POSIX, the class uses os.execvp()-like behavior to execute the child program. On Windows, the class uses the Windows CreateProcess() function.

While I'm here, I'm the author of https://hackinscience.org (a free and opensouce Python learning platform), and I use `friendly-traceback` on a few exercises, so thank you! see:

![Screenshot_2020-06-25 HackInScience - Hello World](https://user-images.githubusercontent.com/239510/85795649-ebc79a80-b738-11ea-85ac-26f5490bbcf6.png)

that's how I (a user in fact) discovered the issue. So thanks for friendly-traceback, and I hope I'll can contribute back a few times :)