### PR TITLE
Add a --formatter option to set a formatter from command line.

### DIFF
--- a/friendly_traceback/formatters.py
+++ b/friendly_traceback/formatters.py
@@ -156,6 +156,29 @@ def no_generic_explanation_with_traceback(info, level=7, **kwargs):
     return result
 
 
+def markdown(info, level):
+    result = []
+    friendly_items = [
+        ("header", "# ", ""),
+        ("message", "", ""),
+        ("parsing_error", "", ""),
+        ("parsing_error_source", "```\n", "```"),
+        ("cause_header", "## ", ""),
+        ("cause", "", ""),
+        ("last_call_header", "## ", ""),
+        ("last_call_source", "```\n", "```"),
+        ("last_call_variables", "Variables:\n```\n", "```"),
+        ("exception_raised_header", "## ", ""),
+        ("exception_raised_source", "```\n", "```"),
+        ("exception_raised_variables", "Variables:\n```\n", "```"),
+       ]
+
+    for item, prefix, suffix in friendly_items:
+        if item in info:
+            result.append(prefix + info[item] + suffix)
+    return "\n\n".join(result)
+
+
 choose_formatter = {
     1: default,
     2: python_traceback_before,


### PR DESCRIPTION
I'm doodling around choosing a formatter from command line.

With this implementation, one could create its own function, and use it by specifying an importable path, like:

    python -m friendly_traceback --formatter their_formatters.html tests/except/test_key_error.py

If accepted, it would be great if other formatters could be used, like:

    python -m friendly_traceback --formatter only_explain

it would require for them to return a string instead of an array though.
We could add the demo html formatter to formatters.py too, and maybe an environment variable if usefull for somebody.

It looks like:
```bash
$ python -m friendly_traceback --formatter friendly_traceback.formatters.markdown tests/except/test_key_error.py  
```
# Python exception:

KeyError: 'c'


## Likely cause based on the information given by Python:

In your program, the name of the key
that cannot be found is 'c'.


## Execution stopped on line 7 of file 'tests/except/test_key_error.py'.


```
       5:     d = {"a": 1, "b": 2}
       6:     try:
    -->7:         d["c"]
```

Variables:
```
    d: {'a': 1, 'b': 2}
```

