### PR TITLE
Updating tests for Python 3.8.3 and 3.9.0

### DIFF
--- a/dev-notes.md
+++ b/dev-notes.md
@@ -7,6 +7,8 @@ We use [black](https://github.com/python/black) for formatting and
 [flake8](http://flake8.pycqa.org/en/latest/) for linting.
 We also use [pytest](https://docs.pytest.org/en/latest/) for testing.
 
+You can use `tox -p auto` to run black, flake8, and pytest in parallel.
+
 Before submitting code, you should ensure that it conforms to the
 formatting requirements and that all tests pass. Feel free to include
 additional unit tests.

--- a/friendly_traceback/__main__.py
+++ b/friendly_traceback/__main__.py
@@ -96,7 +96,8 @@ parser.add_argument(
     "--formatter",
     help="""Specify a formatter function, as a dotted path.
 Example: --formatter friendly_traceback.formatters.markdown
-""")
+""",
+)
 
 
 def import_function(dotted_path: str) -> type:
@@ -113,8 +114,7 @@ def import_function(dotted_path: str) -> type:
         return getattr(module, function_name)
     except AttributeError as err:
         raise ImportError(
-            'Module "%s" does not define a "%s" function'
-            % (module_path, function_name)
+            'Module "%s" does not define a "%s" function' % (module_path, function_name)
         ) from err
 
 

--- a/friendly_traceback/formatters.py
+++ b/friendly_traceback/formatters.py
@@ -171,7 +171,7 @@ def markdown(info, level):
         ("exception_raised_header", "## ", ""),
         ("exception_raised_source", "```\n", "```"),
         ("exception_raised_variables", "Variables:\n```\n", "```"),
-       ]
+    ]
 
     for item, prefix, suffix in friendly_items:
         if item in info:

--- a/friendly_traceback/message_analyzer.py
+++ b/friendly_traceback/message_analyzer.py
@@ -58,6 +58,10 @@ def assign_to_keyword(message="", line="", **kwargs):
         or message == "cannot use named assignment with False"  # Python 3.8
         or message == "cannot use named assignment with None"  # Python 3.8
         or message == "cannot use named assignment with Ellipsis"  # Python 3.8
+        or message == "cannot use assignment expressions with True"  # Python 3.8
+        or message == "cannot use assignment expressions with False"  # Python 3.8
+        or message == "cannot use assignment expressions with None"  # Python 3.8
+        or message == "cannot use assignment expressions with Ellipsis"  # Python 3.8
     ):
         return
 
@@ -363,7 +367,7 @@ def keyword_cannot_be_expression(message="", **kwargs):
 @add_python_message
 def invalid_character_in_identifier(message="", **kwargs):
     _ = current_lang.translate
-    if "invalid character in identifier" in message:
+    if "invalid character" in message:
         return _(
             "You likely used some unicode character that is not allowed\n"
             "as part of a variable name in Python.\n"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 testpaths = tests
+python_files = test_*.py catch_*.py

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 black
 pytest
+pytest-cov
 flake8
 pre-commit

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,12 @@
 # pylint: skip-file
 from setuptools import setup, find_packages
-from friendly_traceback import __version__
 
 with open("README.md", encoding="utf8") as f:
     README = f.read()
 
 setup(
     name="friendly-traceback",
-    version=__version__,
+    version="0.0.29a",
     description="Friendlier tracebacks in any language.",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,0 @@
-# content of conftest.py
-import pytest
-
-
-def pytest_collect_file(parent, path):
-    if path.basename.startswith("test_") or path.basename.startswith("catch_"):
-        return pytest.Module.from_parent(parent, fspath=path)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,22 @@
+[flake8]
+max-line-length = 88
+
+[tox]
+envlist = py36, py37, py38, py39, flake8, black
+isolated_build = True
+skip_missing_interpreters = True
+
+[testenv]
+deps = -r requirements-dev.txt
+commands = pytest --cov-report term-missing --cov-fail-under=80 --cov friendly_traceback
+
+setenv =
+  COVERAGE_FILE=.coverage.{envname}
+
+[testenv:flake8]
+deps = flake8
+commands = flake8 friendly_traceback
+
+[testenv:black]
+deps = black
+commands = black --check --diff friendly_traceback


### PR DESCRIPTION
Bonjour André,

Tests was failing on my laptop for 3.8.3 due to a new error and the wrapping of another.

To ensure I don't miss more of them, I wanted to test with 3.6, 3.7, 3.8 and 3.9, so I took the liberty to add a `tox.ini` file with a basic config, it allows to run tests in parallel in multiple versions of Python (as long as you have them installed), like:

```bash
$ tox -p all
✔ OK py36 in 3.943 seconds
✔ OK py37 in 4.046 seconds
✔ OK flake8 in 4.7 seconds
✔ OK black in 4.884 seconds
✔ OK py38 in 5.909 seconds
✔ OK py39 in 6.697 seconds
__________________________ summary _____________________
  py36: commands succeeded
  py37: commands succeeded
  py38: commands succeeded
  py39: commands succeeded
  flake8: commands succeeded
  black: commands succeeded
  congratulations :)
```

All of this made me change a few things:
 - Had to pass black on `friendly_traceback/`.
 - Added "cannot use assignment expressions with" error message for Python 3.8.
 - "invalid character in identifier" is now "invalid character" in Python 3.9 (but it gives the character).
 - Had to add a `pyproject.toml` because tox requires isolated build to run in parallel, and isolated builds requires a `pyproject.toml` :(
 - Had to hardcode the version in the setup.py: in isolated builds we cannot import the module before installing it: the snake bite its own tail. It could be fixed by using setup.cfg,  like `version = attr: friendly_traceback.__version__`, but I feel this PR is big enough to not convert the setup.py file to setup.cfg, « À chaque jour suffit sa peine », but if you're ok we can convert the `setup.py` file, there's even [a tool for it](https://pypi.org/project/setup-py-upgrade/).
 - Moved the handling of `catch_*.py` from conftest.py to pytest.ini because it was not displaying the details of AssertErrors in catch_*.py files (so you manually added some).
 - Used `pytest.mark.parametrize` instead of a for loop to have more feedback in case of error, but I dropped your `if __main__`, is that bad?
 - Had to unwrap the result (`unwrapped_result = " ".join(result.split())`) because a test was failing due to wrapping (see below).

## using pytest.mark.parametrize

Before when test_syntax_errors failed, it was not telling which one failed, we had to deduce from the assert string:
```
============================== FAILURES ============================================
____________________________ test_syntax_errors ____________________________________________
                                                                                                                                                      
```

After when a test_syntax_errors fail, it shows which file failed:
```
============================== FAILURES ============================================
___________________ test_syntax_errors[raise_syntax_error66]  __________________________________

filename = 'raise_syntax_error66'
```

## The wrapping issue

```
assert cause in result, "\nExpected: %s\nGot: %s" % (cause, result)
AssertionError:
Expected: it reached the end of the file and expected more content.
Got:
    Python exception:
        SyntaxError: unexpected EOF while parsing

[...truncated for readability...]

    Likely cause based on the information given by Python:
        Python tells us that it reached the end of the file
        and expected more content.
```

In this example "end of the file" is separated of "and expected more" by a newline and some spaces, making the test fail.
